### PR TITLE
Changed currentTab to avoid confusion

### DIFF
--- a/src/cortex-devices.ts
+++ b/src/cortex-devices.ts
@@ -2,7 +2,7 @@ import { Data } from './data';
 import { Views } from './views';
 
 export class CortexDevices {
-    private currentTab = 'amps';
+    private currentTab = 'all';
 
     private data = {
         all: [],


### PR DESCRIPTION
Several times when using the application, I didn't see I was on "Amps" because the same devices are listed as on "All". This caused confusion when I tried to search for something other than an amp, and got no results.